### PR TITLE
Update `coreutils-sort` location in adblock

### DIFF
--- a/net/adblock/files/adblock.sh
+++ b/net/adblock/files/adblock.sh
@@ -60,6 +60,7 @@ adb_action="${1:-"start"}"
 adb_packages=""
 adb_sources=""
 adb_cnt=""
+adb_sort="/usr/libexec/sort-coreutils"
 
 # load & check adblock environment
 #
@@ -1854,7 +1855,6 @@ fi
 
 # sort check
 #
-adb_sort="$(command -v sort)"
 if [ ! -x "${adb_sort}" ] || [ "$("${adb_sort}" --version 2>/dev/null | grep -c "coreutils")" = "0" ]
 then
 	f_log "err" "coreutils sort not found or not executable"


### PR DESCRIPTION
Compile tested: (put here arch, model, OpenWrt version)
Run tested: (put here arch, model, OpenWrt version, tests done)

Description:
after https://github.com/openwrt/packages/commit/df10e58a9c7c5ef88eae23c03e497d2f9ca9cedd the install location of `coreutils-*` plugins shifted to `/usr/libexec/`

This pull request updates the `adblock` package to use this new location.